### PR TITLE
Optimize Instructions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,5 +597,12 @@ where
 }
 
 fn is_hex_ascii(byte: &u8) -> bool {
-	matches!(*byte, b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f')
+	// (Tricks from std lib)
+	let digit = byte.wrapping_sub(b'0');
+	if digit < 10 {
+		return true;
+	}
+	// Force the 6th bit to be set to ensure ascii is lower case.
+	let byte = byte | 0b10_0000;
+	b'a' <= byte && byte <= b'f'
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,8 +598,7 @@ where
 
 fn is_hex_ascii(byte: &u8) -> bool {
 	// (Tricks from std lib)
-	let digit = byte.wrapping_sub(b'0');
-	if digit < 10 {
+	if byte.wrapping_sub(b'0') < 10 {
 		return true;
 	}
 	// Force the 6th bit to be set to ensure ascii is lower case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,11 +597,7 @@ where
 }
 
 fn is_hex_ascii(byte: &u8) -> bool {
-	// (Tricks from std lib)
-	if byte.wrapping_sub(b'0') < 10 {
-		return true;
-	}
-	// Force the 6th bit to be set to ensure ascii is lower case.
+	// Convert to lowercase.
 	let byte = byte | 0b10_0000;
-	b'a' <= byte && byte <= b'f'
+	matches!(byte, b'0'..=b'9' | b'a'..=b'f')
 }


### PR DESCRIPTION
If you look in the std lib we do these tricks in `to_digit`.

Smaller wasm is a good thing... (godbolt: https://godbolt.org/z/vocdaKW9x )

I know speed is not the prime reason for the crate, but bench showed a 20% speedup of hex::encode when I ran them. 
(The rest of the benches looked no different.)