### PR TITLE
chore(bench): add const-hex to bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 name = "array-bytes"
 version = "6.2.2"
 dependencies = [
+ "const-hex",
  "criterion",
  "faster-hex",
  "hex",
@@ -116,6 +117,28 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "const-hex"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -212,6 +235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,10 +299,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -304,6 +350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -347,6 +394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,12 +409,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -506,6 +614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +634,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ criterion  = { version = "0.5" }
 faster-hex = { version = "0.9" }
 hex        = { version = "0.4" }
 rustc-hex  = { version = "2.1" }
+const-hex  = { version = "1.1" }
 serde      = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -12,6 +12,8 @@ fn bench_encode(c: &mut Criterion) {
 
 	c.bench_function("hex::encode", |b| b.iter(|| hex::encode(DATA)));
 
+	c.bench_function("const_hex::encode", |b| b.iter(|| const_hex::encode(DATA)));
+
 	c.bench_function("rustc_hex::to_hex", |b| b.iter(|| DATA.to_hex::<String>()));
 
 	c.bench_function("faster_hex::hex_string", |b| b.iter(|| faster_hex::hex_string(DATA)));
@@ -62,6 +64,12 @@ fn bench_decode(c: &mut Criterion) {
 
 			v
 		})
+	});
+
+	c.bench_function("const_hex::decode", |b| {
+		let hex = const_hex::encode(DATA);
+
+		b.iter(|| const_hex::decode(&hex).unwrap())
 	});
 
 	c.bench_function("hex::decode", |b| {


### PR DESCRIPTION
```
array_bytes::bytes2hex  time:   [144.29 µs 146.18 µs 149.05 µs]
                        change: [-1.3871% -0.3029% +0.7608%] (p = 0.61 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

hex::encode             time:   [149.35 µs 150.45 µs 151.82 µs]
                        change: [+0.4094% +1.3222% +2.2776%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  10 (10.00%) high mild
  4 (4.00%) high severe

const_hex::encode       time:   [2.2628 µs 2.3300 µs 2.4055 µs]
                        change: [+1.2185% +5.2719% +9.5136%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

rustc_hex::to_hex       time:   [150.38 µs 151.80 µs 153.60 µs]
                        change: [+0.4301% +1.3696% +2.3517%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe

faster_hex::hex_string  time:   [17.824 µs 17.926 µs 18.044 µs]
                        change: [-2.4599% -1.4254% -0.4763%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

faster_hex::hex_encode_fallback
                        time:   [17.770 µs 17.845 µs 17.932 µs]
                        change: [-5.5325% -4.6448% -3.8199%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

array_bytes::hex2bytes  time:   [121.79 µs 122.94 µs 124.44 µs]
                        change: [-8.1342% -5.9473% -3.9038%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

array_bytes::hex2bytes_unchecked
                        time:   [104.80 µs 106.83 µs 109.45 µs]
                        change: [-8.1132% -5.2278% -2.7215%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  9 (9.00%) high mild
  4 (4.00%) high severe

array_bytes::hex2slice  time:   [109.99 µs 110.61 µs 111.35 µs]
                        change: [-16.566% -12.715% -8.9614%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

array_bytes::hex2slice_unchecked
                        time:   [106.36 µs 107.01 µs 107.73 µs]
                        change: [+0.1300% +0.8262% +1.5455%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  13 (13.00%) high mild
  2 (2.00%) high severe

const_hex::decode       time:   [22.506 µs 22.620 µs 22.746 µs]
                        change: [-0.9531% -0.1817% +0.5044%] (p = 0.64 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

hex::decode             time:   [158.77 µs 159.75 µs 160.91 µs]
                        change: [-4.1689% -1.5886% +0.2738%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

hex::decode_to_slice    time:   [92.014 µs 92.959 µs 93.992 µs]
                        change: [-5.6023% -3.8389% -2.1713%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

rustc_hex::from_hex     time:   [164.63 µs 165.58 µs 166.69 µs]
                        change: [-2.6146% -1.9408% -1.2730%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  9 (9.00%) high severe

faster_hex::hex_decode  time:   [38.787 µs 39.093 µs 39.486 µs]
                        change: [-1.5174% -0.1346% +1.0835%] (p = 0.85 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

faster_hex::hex_decode_unchecked
                        time:   [16.099 µs 16.178 µs 16.267 µs]
                        change: [-0.7121% -0.0005% +0.6746%] (p = 1.00 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

faster_hex::hex_decode_fallback
                        time:   [16.057 µs 16.154 µs 16.269 µs]
                        change: [-0.6458% -0.0882% +0.4780%] (p = 0.75 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  10 (10.00%) high severe
```