### PR TITLE
Release `v9.2.2`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,12 +10,10 @@ max_line_length=100
 tab_width=4
 trim_trailing_whitespace=true
 
-[*.py]
-charset=utf-8
+[*.{py,slint}]
 indent_size=4
 indent_style=space
 
 [*.{sh,yml,yaml}]
 indent_size=2
 indent_style=space
-tab_width=8

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,18 @@
-# System
-.DS_Store
-
-# Integrated Development Environment
-.idea
+# Integrated development environment.
 .vscode
 
-# Package Manager
-## Cargo
+# Package manager.
+## Cargo.
 target
-## Npm
-package-lock.json
+## Python
+__pycache__
+## NPM.
 node_modules
-build
+
+# System.
+.DS_Store
+
+# Test data.
+*.bak
+.env
+tmp

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,5 @@
 # Basic
-edition    = "2021"
+edition    = "2024"
 hard_tabs  = true
 max_width  = 100
 tab_spaces = 4

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,34 +1,49 @@
+### v9.2.2
+
+- Fix case sensitivity in `ser_hexify_prefixed_upper`.
+- Bump dependencies.
+- Format code.
+
 ### v9.2.1
+
 - Enable all features for docs.rs.
 
 ### v9.2.0
+
 - Include examples in the lib.rs.
 - Upgrade edition to 2024.
 - Bump dependencies.
 
 ### v9.1.2
+
 - Add `ser_bytes_stringify` and `de_bytes_destringify`.
 
 ### v9.1.1
+
 - Integrate `serde_bytes`.
 
 ### v9.1.0
+
 - Use reference instead of value in `Hexify` trait and related serialize functions.
 
 ### v9.0.0
+
 - Expose more friendly APIs, `Hexify` and `DeHexify` traits.
 - Un-public some tiny functions to encourage using `Hexify` and `DeHexify` traits.
 - Improve docs.
 - Restructure the code.
 
 ### v8.0.0
+
 - Improve performance.
 
 ### v7.1.0
+
 - Rename `se_hex` to `ser_hex`.
 - Rename `se_hex_without_prefix` to `ser_hex_without_prefix`.
 
 ### v7.0.0
+
 - Improve docs.
 - Improve tests.
 - Bump dependencies.
@@ -37,104 +52,129 @@
 - Remove `de_hex2bytes`.
 
 ### v6.2.3
+
 - Add `slice2array_ref` and `slice2array_ref_unchecked`.
 - Bump dependencies.
 
 ### v6.2.2
+
 - Improve documentation.
 
 ### v6.2.1
+
 - Add `prefix_with` and `suffix_with`.
 - Bump dependencies.
 
 ### v6.2.0
+
 - Adjust generics order.
 - Bump dependencies.
 
 ### v6.1.0
+
 - Improve expression.
 - Improve `TryFromHex` and add `Hex`.
 
 ### v6.0.0
+
 - Optimize algorithm.
 - Bump dependencies.
 
 ### v5.1.0
+
 - Rename error fields.
 
 ### v5.0.0
+
 - Optimize algorithm.
 - Improve documentation.
 - Support `AsRef<T>` input.
 - Add `hex2slice` and `hex2slice_unchecked`.
 
 ### v4.2.0
+
 - Bump dependencies.
 - Update CI.
 - Update license.
 
 ### v4.1.0
+
 - Mark `hex_bytes2hex_str_unchecked` as unsafe.
 
 ### v4.0.0
+
 - Use `is_hex_ascii` to optimize performance.
 - Add benchmark results.
 - Add `hex_bytes2hex_str` and `hex_bytes2hex_str_unchecked`.
 - Add fuzzing.
 
 ### v3.0.0
+
 - Break `hex_into` into `hex_into` and `hex_n_into`.
 - Break `hex_into_unchecked` into `hex_into_unchecked` and `hex_n_into_unchecked`.
 
 ### v2.0.2
+
 - Bump dependencies.
 - Update README.
 - Update CI.
 
 ### v2.0.1
+
 - Fix tests.
 
 ### v2.0.0
+
 - Split `dyn_*` to `slice_*` and `vec_*`.
 - Remove all the unsafe usage.
 
 ### v1.6.0
+
 - Disable generic input. (people should know what are they going to do)
 - Bump dependencies.
 
 ### v1.5.2
+
 - Update documentation.
 - Update code format.
 - Bump dependencies.
 
 ### v1.5.1
+
 - Update description.
 
 ### v1.5.0
+
 - Revert *"Use `String` instead `&str` in `serde`"*.
 - Bump dependencies.
 - Rust edition 2021.
 
 ### v1.4.1
+
 - Use `String` instead `&str` in `serde`.
 
 ### v1.4.0
+
 - Bump `serde`.
 - Add more documentation.
 - Add more tests.
 - Rename `hexd2num` to `de_hex2num`, `hexd2bytes` to `de_hex2bytes`.
 
 ### v1.3.3
+
 - Allow explicit generic argument.
 
 ### v1.3.2
+
 - Add `dyn_into`.
 
 ### v1.3.0
+
 - Add `hex2array`, `hex_try_into` and `hex_into_unchecked`.
 - Support `serde`.
 
 ### v1.2.0
+
 - Deprecated macro `hex2array_unchecked`.
 - Introduce function `hex2array_unchecked`.
 - Require at least Rust `1.51.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "array-bytes"
-version = "9.2.1"
+version = "9.2.2"
 dependencies = [
  "const-hex",
  "criterion",
@@ -46,9 +46,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -103,18 +103,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -128,9 +128,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "const-hex"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -150,25 +150,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -181,7 +178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -272,33 +269,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -531,9 +520,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "Apache-2.0/GPL-3.0"
 name = "array-bytes"
 readme = "README.md"
 repository = "https://github.com/hack-ink/array-bytes"
-version = "9.2.1"
+version = "9.2.2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -43,7 +43,7 @@ smallvec    = { version = "1.15" }
 
 [dev-dependencies]
 const-hex  = { version = "1.14" }
-criterion  = { version = "0.5" }
+criterion  = { version = "0.6" }
 faster-hex = { version = "0.10" }
 hex_crate  = { package = "hex", version = "0.4" }
 rustc-hex  = { version = "2.1" }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <div align="center">
 
 # array-bytes
-### A collection of Array/Bytes/Hex utilities with full No-STD compatibility.
+
+### A collection of Array/Bytes/Hex utilities with full No-STD compatibility
 
 [![License GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -12,8 +13,8 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/hack-ink/array-bytes?color=red&style=plastic)](https://github.com/hack-ink/array-bytes)
 </div>
 
-
 ## Usage
+
 Here are a few quick examples of the most commonly used operations: hexifying and dehexifying.
 
 However, this crate also offers many other utilities for Array/Bytes/Hex, each with comprehensive documentation and examples. Check them out on [docs.rs](https://docs.rs/array-bytes)!
@@ -88,6 +89,7 @@ assert_eq!(
 ```
 
 ## Benchmark
+
 The following benchmarks were run on a `Apple M4 Max 64GB - macOS 15.2 (24C101)`.
 
 <div align="right"><sub>Fri, Jan 3rd, 2025</sub></div>
@@ -113,6 +115,7 @@ rustc_hex::from_hex              time: [106.68 µs 107.45 µs 108.31 µs]
 ```
 
 To run the benchmarks yourself:
+
 ```sh
 git clone https://github.com/hack-ink/array-bytes
 cd array-bytes
@@ -122,5 +125,6 @@ cargo bench
 <div align="right">
 
 ## License
+
 <sup>Licensed under either of <a href="LICENSE-APACHE">Apache-2.0</a> or <a href="LICENSE-GPL3">GPL-3.0</a> at your option.</sup>
 </div>

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "array-bytes"
-version = "9.0.0"
+version = "9.2.1"
 dependencies = [
  "smallvec",
 ]
@@ -24,10 +24,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.4"
+name = "bitflags"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "cc"
+version = "1.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -35,29 +41,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
+name = "cfg-if"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom",
  "libc",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "shlex"
@@ -67,6 +98,24 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -151,10 +151,10 @@ where
 /// ```
 pub fn ser_hexify_prefixed_upper<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
-	S: Serializer,
-	T: Hexify,
+        S: Serializer,
+        T: Hexify,
 {
-	serializer.serialize_str(&value.hexify_prefixed())
+        serializer.serialize_str(&value.hexify_prefixed_upper())
 }
 
 /// Deserialize string to bytes.
@@ -399,11 +399,11 @@ fn serde_should_work() {
 	let result = serde_json::to_string(&ljf);
 	assert!(result.is_ok());
 
-	let json = result.unwrap();
-	assert_eq!(
-		json,
-		r#"{"_0":"34","_1":"208","_2":"0x4f5da2","_3":"0x4f5da2","_4":"4f5da2","_5":"4F5DA2","_6":"0x4c6f7665204a616e6520466f7265766572","_7":"0x4c6f7665204a616e6520466f7265766572","_8":"Love Jane Forever"}"#
-	);
+        let json = result.unwrap();
+        assert_eq!(
+                json,
+                r#"{"_0":"34","_1":"208","_2":"0x4f5da2","_3":"0x4F5DA2","_4":"4f5da2","_5":"4F5DA2","_6":"0x4c6f7665204a616e6520466f7265766572","_7":"0x4C6F7665204A616E6520466F7265766572","_8":"Love Jane Forever"}"#
+        );
 
 	let result = serde_json::from_str::<LjfPredefined>(&json);
 	assert!(result.is_ok());

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -151,10 +151,10 @@ where
 /// ```
 pub fn ser_hexify_prefixed_upper<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
-        S: Serializer,
-        T: Hexify,
+	S: Serializer,
+	T: Hexify,
 {
-        serializer.serialize_str(&value.hexify_prefixed_upper())
+	serializer.serialize_str(&value.hexify_prefixed_upper())
 }
 
 /// Deserialize string to bytes.
@@ -399,11 +399,11 @@ fn serde_should_work() {
 	let result = serde_json::to_string(&ljf);
 	assert!(result.is_ok());
 
-        let json = result.unwrap();
-        assert_eq!(
-                json,
-                r#"{"_0":"34","_1":"208","_2":"0x4f5da2","_3":"0x4F5DA2","_4":"4f5da2","_5":"4F5DA2","_6":"0x4c6f7665204a616e6520466f7265766572","_7":"0x4C6F7665204A616E6520466F7265766572","_8":"Love Jane Forever"}"#
-        );
+	let json = result.unwrap();
+	assert_eq!(
+		json,
+		r#"{"_0":"34","_1":"208","_2":"0x4f5da2","_3":"0x4F5DA2","_4":"4f5da2","_5":"4F5DA2","_6":"0x4c6f7665204a616e6520466f7265766572","_7":"0x4C6F7665204A616E6520466F7265766572","_8":"Love Jane Forever"}"#
+	);
 
 	let result = serde_json::from_str::<LjfPredefined>(&json);
 	assert!(result.is_ok());


### PR DESCRIPTION
## Summary
- call `hexify_prefixed_upper` in `ser_hexify_prefixed_upper`
- update serde test expectations for uppercase hex

## Testing
- `cargo test --quiet` *(fails: could not download Rust toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683ff08b415c83269ebb8c3b6320a53d